### PR TITLE
TAS-2600/Preview-Credential

### DIFF
--- a/src/core/adaptors/credentials/index.adaptors.ts
+++ b/src/core/adaptors/credentials/index.adaptors.ts
@@ -4,10 +4,13 @@ import {
   createCredentialWithRecipient,
   createRecipient,
   deleteCredential,
+  deleteCredentials,
   deleteRecipient,
   getCredentials,
   getRecipients,
   revokeCredential,
+  revokeCredentials,
+  sendCredentials,
   updateRecipient,
 } from 'src/core/api';
 import { requestKYB } from 'src/core/api/kyb/kyb.api';
@@ -21,13 +24,14 @@ import {
   CredentialStatus,
   RecipientReq,
   RecipientRes,
+  SendCredentialReq,
   SuccessRes,
 } from '..';
 
 export const getCredentialsAdaptor = async (
   page = 1,
   limit = 10,
-  filters?: { schema_id: string },
+  filters?: { schema_id: string; sent: boolean },
 ): Promise<AdaptorRes<CredentialsRes>> => {
   const { email } = store.getState().user.userProfile;
   try {
@@ -89,6 +93,16 @@ export const revokeCredentialAdaptor = async (credentialId: string): Promise<Ada
   }
 };
 
+export const revokeCredentialsAdaptor = async (credentialIds: string[]): Promise<AdaptorRes<SuccessRes>> => {
+  try {
+    await revokeCredentials({ credentials: credentialIds });
+    return { data: { message: 'succeed' }, error: null };
+  } catch (error) {
+    console.error('Error in revoking credentials', error);
+    return { data: null, error: 'Error in revoking credentials' };
+  }
+};
+
 export const deleteCredentialAdaptor = async (credentialId: string): Promise<AdaptorRes<SuccessRes>> => {
   try {
     await deleteCredential(credentialId);
@@ -96,6 +110,16 @@ export const deleteCredentialAdaptor = async (credentialId: string): Promise<Ada
   } catch (error) {
     console.error('Error in deleting credential', error);
     return { data: null, error: 'Error in deleting credential' };
+  }
+};
+
+export const deleteCredentialsAdaptor = async (credentialIds: string[]): Promise<AdaptorRes<SuccessRes>> => {
+  try {
+    await deleteCredentials({ credentials: credentialIds });
+    return { data: { message: 'succeed' }, error: null };
+  } catch (error) {
+    console.error('Error in deleting credentials', error);
+    return { data: null, error: 'Error in deleting credentials' };
   }
 };
 
@@ -211,5 +235,15 @@ export const addCredentialRecipientAdaptor = async (
   } catch (error) {
     console.error('Error in creating a credential with recipient', error);
     return { data: null, error: 'Error in creating a credential with recipient' };
+  }
+};
+
+export const sendCredentialsAdaptors = async (payload: SendCredentialReq) => {
+  try {
+    await sendCredentials(payload);
+    return { data: { message: 'succeed' }, error: null };
+  } catch (error) {
+    console.error('Error in sending the credentials to recipients', error);
+    return { data: null, error: 'Error in sending the credentials to recipients' };
   }
 };

--- a/src/core/adaptors/credentials/index.types.ts
+++ b/src/core/adaptors/credentials/index.types.ts
@@ -1,6 +1,6 @@
 import { CredentialClaims, PaginateRes } from 'src/core/api';
 
-export type CredentialStatus = 'ACTIVE' | 'PENDING' | 'REVOKED' | 'ISSUED' | 'CREATED';
+export type CredentialStatus = 'ACTIVE' | 'PENDING' | 'REVOKED' | 'ISSUED' | 'CREATED' | 'CLAIMED';
 
 export type Credential = {
   id: string;
@@ -44,3 +44,8 @@ export type RecipientReq = {
 };
 
 export type CredentialRecipientReq = Omit<CredentialReq, 'selectedRecipient'> & RecipientReq;
+
+export interface SendCredentialReq {
+  schema_id: string;
+  message?: string;
+}

--- a/src/core/api/credentials/credentials.api.ts
+++ b/src/core/api/credentials/credentials.api.ts
@@ -1,4 +1,11 @@
-import { CredentialReq, CredentialRes, CredentialListRes, CredentialRecipientReq } from './credentials.types';
+import {
+  CredentialReq,
+  CredentialRes,
+  CredentialListRes,
+  CredentialRecipientReq,
+  CredentialIds,
+  SendCredentialsReq,
+} from './credentials.types';
 import { post, del, get, put, patch } from '../http';
 import { FilterReq, PaginateReq, SuccessRes } from '../types';
 
@@ -12,6 +19,10 @@ export async function updateCredential(id: string, payload: CredentialReq): Prom
 
 export async function revokeCredential(id: string): Promise<CredentialRes> {
   return (await patch<CredentialRes>(`credentials/${id}/revoke`)).data;
+}
+
+export async function revokeCredentials(payload: CredentialIds): Promise<SuccessRes> {
+  return (await patch<SuccessRes>('credentials/revoke', payload)).data;
 }
 
 export async function getCredential(id: string): Promise<CredentialRes> {
@@ -30,6 +41,14 @@ export async function deleteCredential(id: string): Promise<SuccessRes> {
   return (await del<SuccessRes>(`credentials/${id}`)).data;
 }
 
+export async function deleteCredentials(payload: CredentialIds): Promise<SuccessRes> {
+  return (await post<SuccessRes>('credentials/delete', payload)).data;
+}
+
 export async function createCredentialWithRecipient(payload: CredentialRecipientReq): Promise<CredentialRes> {
   return (await post<CredentialRes>('credentials/with-recipient', payload)).data;
+}
+
+export async function sendCredentials(payload: SendCredentialsReq): Promise<SuccessRes> {
+  return (await post<SuccessRes>('credentials/notify/via-schema', payload)).data;
 }

--- a/src/core/api/credentials/credentials.types.ts
+++ b/src/core/api/credentials/credentials.types.ts
@@ -41,3 +41,12 @@ export interface CredentialRecipientReq {
   credential: Omit<CredentialReq, 'recipient_id'>;
   recipient: RecipientReq;
 }
+
+export interface CredentialIds {
+  credentials: string[];
+}
+
+export interface SendCredentialsReq {
+  schema_id: string;
+  message?: string;
+}

--- a/src/core/translation/locales/en/credentials/credential.json
+++ b/src/core/translation/locales/en/credentials/credential.json
@@ -28,6 +28,7 @@
     "active": "Active",
     "pending": "Pending",
     "revoked": "Revoked",
-    "created": "Created"
+    "created": "Created",
+    "claimed": "Claimed"
   }
 }

--- a/src/core/translation/locales/en/credentials/credentialCreate.json
+++ b/src/core/translation/locales/en/credentials/credentialCreate.json
@@ -38,6 +38,20 @@
       "required": "This field is required"
     }
   },
+  "credential-step3-title": "Send credentials",
+  "credential-step3": {
+    "header": "Send to recipients",
+    "message": "Message",
+    "message-explanation": "This message will be sent as an email to your credential recipients.",
+    "message-placeholder": "Enter a message...",
+    "preview": "Email Preview",
+    "preview-header": "You have been issued {{name}} by {{issuer}}",
+    "preview-issuer": "Issuer",
+    "preview-title": "Credential title",
+    "preview-claim-text": "Please click on the link below and Scan the QR Code that will be shown with your Socious Wallet",
+    "preview-claim-button": "Claim your credential",
+    "preview-security-text": "  For security purposes, please do not forward this email and keep your credential secure. The credential import links and QR code in this email will expire within 1 week."
+  },
   "credential-continue-button": "Continue",
   "credential-send-button": "Send",
   "credential-cancel-button": "Cancel"

--- a/src/core/translation/locales/jp/credentials/credential.json
+++ b/src/core/translation/locales/jp/credentials/credential.json
@@ -28,6 +28,7 @@
     "active": "アクティブ",
     "pending": "保留中",
     "revoked": "取り消し済み",
-    "created": "作成された"
+    "created": "作成された",
+    "claimed": "取得済み"
   }
 }

--- a/src/core/translation/locales/jp/credentials/credentialCreate.json
+++ b/src/core/translation/locales/jp/credentials/credentialCreate.json
@@ -38,6 +38,20 @@
       "required": "このフィールドは必須です"
     }
   },
+  "credential-step3-title": "認証情報を送信",
+  "credential-step3": {
+    "header": "受信者に送信",
+    "message": "メッセージ",
+    "message-explanation": "このメッセージは、認証情報の受信者にメールとして送信されます。",
+    "message-placeholder": "メッセージを入力してください...",
+    "preview": "メールのプレビュー",
+    "preview-header": "{{issuer}}から{{name}}が発行されました",
+    "preview-issuer": "発行者",
+    "preview-title": "クレデンシャルタイトル",
+    "preview-claim-text": "以下のリンクをクリックし、表示されるQRコードをSocious Walletでスキャンしてください。",
+    "preview-claim-button": "クレデンシャルを取得",
+    "preview-security-text": "セキュリティ上の理由から、このメールを転送せず、クレデンシャルを安全に保管してください。このメール内のクレデンシャルインポートリンクとQRコードは1週間で有効期限が切れます。"
+  },
   "credential-continue-button": "続行",
   "credential-send-button": "送信",
   "credential-cancel-button": "キャンセル"

--- a/src/modules/Credential/containers/IssuedList/index.tsx
+++ b/src/modules/Credential/containers/IssuedList/index.tsx
@@ -19,10 +19,22 @@ import { useIssuedList } from './useIssuedList';
 
 const IssuedList = () => {
   const {
-    data: { translate, currentList, page, totalPage, selectedCredential, status, openModal, url, disableRevoke },
+    data: {
+      translate,
+      currentList,
+      page,
+      totalPage,
+      selectedAll,
+      selectedCredentials,
+      status,
+      openModal,
+      url,
+      disableRevoke,
+    },
     operations: {
       onChangePage,
       onSelectCredential,
+      onSelectAllCredentials,
       handleCloseModal,
       onRevokeClick,
       onRevokeCredential,
@@ -116,8 +128,8 @@ const IssuedList = () => {
           </Button>
           <Button
             variant="outlined"
-            color={!selectedCredential ? 'inherit' : 'secondary'}
-            disabled={!selectedCredential}
+            color={!selectedCredentials.length ? 'inherit' : 'secondary'}
+            disabled={!selectedCredentials.length}
             onClick={onDeleteClick}
           >
             {translate('credential-delete-button')}
@@ -132,7 +144,19 @@ const IssuedList = () => {
                     {headerGroup.headers.map(header =>
                       header.isPlaceholder ? null : (
                         <th id={header.id} key={header.id} className={css['header__item']}>
-                          {flexRender(header.column.columnDef.header, header.getContext())}
+                          {header.id === 'recipient_name' ? (
+                            <div className="flex justify-start items-center gap-3 text-Gray-light-mode-600">
+                              <Checkbox
+                                id="select-all"
+                                disabled={!currentList.length}
+                                checked={selectedAll}
+                                onChange={e => onSelectAllCredentials(e.target.checked)}
+                              />
+                              {flexRender(header.column.columnDef.header, header.getContext())}
+                            </div>
+                          ) : (
+                            flexRender(header.column.columnDef.header, header.getContext())
+                          )}
                         </th>
                       ),
                     )}
@@ -152,7 +176,7 @@ const IssuedList = () => {
                                 {item && (
                                   <Checkbox
                                     id={item.id}
-                                    checked={selectedCredential === item.id}
+                                    checked={selectedCredentials.includes(item.id)}
                                     onChange={() => onSelectCredential(item.id)}
                                   />
                                 )}

--- a/src/modules/Credential/containers/PreviewCredential/index.module.scss
+++ b/src/modules/Credential/containers/PreviewCredential/index.module.scss
@@ -1,0 +1,149 @@
+@import 'src/styles/utilities/_mixins.scss';
+@import 'src/styles/constants/_primitives.scss';
+
+.container {
+    @include flex(normal, normal, column);
+    gap: 1.5rem;
+
+    .header {
+        font-size: 30px;
+        font-weight: 600;
+        line-height: 38px;
+        color: $color-grey-900;
+    }
+
+    .row {
+        @include flex(normal, flex-start);
+        gap: 2rem;
+
+        @media (max-width: $md) {
+            flex-direction: column;
+        }
+
+        &__left {
+            @include flex(normal, normal, column);
+            flex: 25%;
+            font-size: 14px;
+            font-weight: 600;
+            color: $color-grey-700;
+            line-height: 20px;
+
+            @media (max-width: $lg) {
+                flex: 20%;
+            }
+
+            @media (max-width: $md) {
+                flex: 1;
+                width: 100%;
+            }
+        }
+
+        &__subtitle {
+            font-weight: 400;
+            color: $color-grey-600;
+        }
+
+        &__right {
+            @include flex(normal, flex-start, column);
+            gap: 0.5rem;
+            flex: 50%;
+            min-width: 32rem;
+
+            @media (max-width: $lg) {
+                flex: 60%;
+                min-width: 20rem;
+            }
+
+            @media (max-width: $md) {
+                flex: 1;
+                width: 100%;
+            }
+        }
+
+        .preview {
+            padding: 2rem;
+            background-color: $color-grey-50;
+            box-shadow: $shadow-xs;
+            border-radius: $radius-md;
+
+            @media (max-width: $md) {
+                padding: 1rem;
+            }
+
+            &__content {
+                width: 100%;
+                @include flex(normal, stretch, column);
+                gap: 2rem;
+                background-color: $color-white;
+                border-radius: $radius-md;
+                padding: 0 1.5rem;
+            }
+
+            &__logo {
+                @include flex(center, center);
+                padding: 1.5rem 0;
+            }
+
+            &__header {
+                font-size: 24px;
+                font-weight: 600;
+                line-height: 32px;
+                color: $color-grey-900;
+            }
+
+            &__message {
+                margin-top: -0.5rem;
+                white-space: pre-wrap;
+                font-size: 16px;
+                line-height: 24px;
+                color: $color-grey-600;
+            }
+
+            &__table {
+                @include flex(normal, stretch, column);
+                border: 1px solid $color-grey-200;
+                border-radius: $radius-md;
+            }
+
+            &__detail {
+                @include flex(normal, stretch, column);
+                padding: 1rem 1.5rem;
+                font-size: 14px;
+                font-weight: 500;
+                line-height: 20px;
+                color: $color-grey-900;
+
+                & + .preview__detail {
+                    border-top: 1px solid $color-grey-200;
+                }
+
+                &--lighter {
+                    font-weight: 400;
+                    color: $color-grey-600;
+                }
+            }
+
+            &__claim {
+                @include flex(normal, flex-start, column);
+                gap: 0.75rem;
+                font-size: 14px;
+                font-weight: 500;
+                line-height: 20px;
+                color: $color-grey-900;
+            }
+
+            &__button {
+                align-self: center;
+                pointer-events: none;
+            }
+
+            &__subtitle {
+                padding: 2rem 0;
+                font-size: 14px;
+                font-weight: 400;
+                line-height: 20px;
+                color: $color-grey-600;
+            }
+        }
+    }
+}

--- a/src/modules/Credential/containers/PreviewCredential/index.tsx
+++ b/src/modules/Credential/containers/PreviewCredential/index.tsx
@@ -1,0 +1,79 @@
+import { Divider } from '@mui/material';
+import { forwardRef } from 'react';
+import logo from 'src/assets/logo/logo.svg';
+import Button from 'src/modules/General/components/Button';
+import Input from 'src/modules/General/components/Input';
+
+import css from './index.module.scss';
+import { FormHandles, PreviewCredentialProps } from './index.types';
+import { usePreviewCredential } from './usePreviewCredential';
+
+const PreviewCredential = forwardRef<FormHandles, PreviewCredentialProps>(
+  ({ credentialDetail, onSendCredential }, ref) => {
+    const {
+      data: { translate, register, formRef, message },
+    } = usePreviewCredential(onSendCredential, ref);
+    const { name = '', issuer = '' } = credentialDetail || {};
+
+    return (
+      <form className={css['container']} ref={formRef}>
+        <h1 className={css['header']}>{translate('credential-step3.header')}</h1>
+        <Divider />
+        <div className={css['row']}>
+          <div className={css['row__left']}>
+            {translate('credential-step3.message')}
+            <span className={css['row__subtitle']}>{translate('credential-step3.message-explanation')}</span>
+          </div>
+          <div className={css['row__right']}>
+            <Input
+              register={register}
+              id="message"
+              name="message"
+              placeholder={translate('credential-step3.message-placeholder')}
+              customHeight="180px"
+              multiline
+              containerClassName="w-full"
+            />
+          </div>
+          <div className={css['row__left']} />
+        </div>
+        <Divider />
+        <div className={css['row']}>
+          <div className={css['row__left']}>{translate('credential-step3.preview')}</div>
+          <div className={`${css['row__right']} ${css['preview']}`}>
+            <div className={css['preview__content']}>
+              <div className={css['preview__logo']}>
+                <img src={logo} alt="Shin-Logo" />
+              </div>
+              <span className={css['preview__header']}>
+                {translate('credential-step3.preview-header', { name, issuer })}
+              </span>
+              <div className={css['preview__message']}>{message}</div>
+              <div className={css['preview__table']}>
+                <div className={css['preview__detail']}>
+                  {translate('credential-step3.preview-issuer')}
+                  <span className={css['preview__detail--lighter']}>{issuer}</span>
+                </div>
+                <div className={css['preview__detail']}>
+                  {translate('credential-step3.preview-title')}
+                  <span className={css['preview__detail--lighter']}>{name}</span>
+                </div>
+              </div>
+              <div className={css['preview__claim']}>
+                {translate('credential-step3.preview-claim-text')}
+                <Button color="primary" customStyle={css['preview__button']}>
+                  {translate('credential-step3.preview-claim-button')}
+                </Button>
+              </div>
+              <p className={css['preview__subtitle']}>{translate('credential-step3.preview-security-text')}</p>
+            </div>
+          </div>
+          <div className={css['row__left']} />
+        </div>
+      </form>
+    );
+  },
+);
+
+PreviewCredential.displayName = 'PreviewCredential';
+export default PreviewCredential;

--- a/src/modules/Credential/containers/PreviewCredential/index.types.ts
+++ b/src/modules/Credential/containers/PreviewCredential/index.types.ts
@@ -1,0 +1,17 @@
+export interface FormHandles {
+  submitForm: () => void;
+}
+
+export type Form = {
+  message?: string;
+};
+
+export type CredentialDetail = {
+  name: string;
+  issuer: string;
+};
+
+export interface PreviewCredentialProps {
+  credentialDetail: CredentialDetail;
+  onSendCredential: (message: string) => void;
+}

--- a/src/modules/Credential/containers/PreviewCredential/usePreviewCredential.tsx
+++ b/src/modules/Credential/containers/PreviewCredential/usePreviewCredential.tsx
@@ -1,0 +1,36 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useImperativeHandle, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import * as yup from 'yup';
+
+import { Form } from './index.types';
+
+const schema = yup
+  .object()
+  .shape({
+    message: yup.string(),
+  })
+  .required();
+
+export const usePreviewCredential = (onSendCredential: (message: string) => void, ref) => {
+  const { t: translate } = useTranslation();
+  const { register, watch, handleSubmit } = useForm<Form>({
+    mode: 'all',
+    resolver: yupResolver(schema),
+  });
+  const formRef = useRef<HTMLFormElement>(null);
+  useImperativeHandle(ref, () => ({
+    submitForm: () => handleSubmit(onSubmit)(),
+  }));
+  const message = watch('message');
+
+  const onSubmit = (formData: Form) => {
+    const { message = '' } = formData || {};
+    onSendCredential(message);
+  };
+
+  return {
+    data: { translate, register, formRef, message },
+  };
+};

--- a/src/modules/Credential/containers/SchemaCredentialList/index.tsx
+++ b/src/modules/Credential/containers/SchemaCredentialList/index.tsx
@@ -4,11 +4,11 @@ import { useMemo } from 'react';
 import { Credential } from 'src/core/adaptors';
 import { formatDate } from 'src/core/helpers/relative-time';
 import Button from 'src/modules/General/components/Button';
-import Checkbox from 'src/modules/General/components/Checkbox';
 import FeaturedIcon from 'src/modules/General/components/FeaturedIcon';
+import Icon from 'src/modules/General/components/Icon';
 import Pagination from 'src/modules/General/components/Pagination';
-import Status from 'src/modules/General/components/Status';
 import ConfirmModal from 'src/modules/General/containers/ConfirmModal';
+import variables from 'src/styles/constants/_exports.module.scss';
 
 import css from './index.module.scss';
 import { useSchemaCredentialList } from './useSchemaCredentialList';
@@ -17,12 +17,11 @@ import { SchemaCredentialListProps } from './index.types';
 
 const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
   selectedSchema,
-  selectedCredentials,
-  onSelectCredential,
-  onSelectAllCredentials,
+  schemaCredentialList,
+  onUpdateSchemaCredentialList,
 }) => {
   const {
-    data: { translate, currentList, page, totalPage, status, openModal },
+    data: { translate, currentList, page, totalPage, openModal },
     operations: {
       onChangePage,
       onAddCredentialRecipientClick,
@@ -31,7 +30,7 @@ const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
       onDeleteClick,
       onDeleteCredential,
     },
-  } = useSchemaCredentialList(selectedSchema.id, selectedCredentials, onSelectCredential);
+  } = useSchemaCredentialList(schemaCredentialList, onUpdateSchemaCredentialList);
 
   const columns = useMemo<ColumnDef<Credential>[]>(
     () => [
@@ -66,13 +65,17 @@ const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
         cell: ({ getValue }: { getValue: Getter<string> }) => (getValue() ? formatDate(getValue()) : ''),
       },
       {
-        id: 'status',
-        header: translate('credential-table.status'),
-        accessorKey: 'status',
+        id: 'actions',
+        header: '',
+        accessorKey: 'id',
         cell: ({ getValue }: { getValue: Getter<string> }) => (
-          <div className="flex items-center">
-            <Status {...status[getValue()]} />
-          </div>
+          <Icon
+            name="trash-01"
+            fontSize={20}
+            cursor="pointer"
+            color={variables.color_grey_600}
+            onClick={() => onDeleteClick(getValue())}
+          />
         ),
       },
     ],
@@ -97,14 +100,6 @@ const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
           <Button variant="outlined" color="primary" onClick={onAddCredentialRecipientClick}>
             {translate('credential-step2.add-button')}
           </Button>
-          <Button
-            variant="outlined"
-            color={!selectedCredentials.length ? 'inherit' : 'primary'}
-            disabled={!selectedCredentials.length || !currentList.length}
-            onClick={onDeleteClick}
-          >
-            {translate('credential-step2.delete-button')}
-          </Button>
         </div>
         <div className={css['table']}>
           <div className="block overflow-auto">
@@ -112,22 +107,13 @@ const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
               <thead className={css['table__header']}>
                 {table.getHeaderGroups().map(headerGroup => (
                   <tr key={headerGroup.id}>
-                    {headerGroup.headers.map(header => (
-                      <th id={header.id} key={header.id} className={css['table__item']}>
-                        {header.id === 'recipient_name' ? (
-                          <div className="flex justify-start items-center gap-3 text-Gray-light-mode-600">
-                            <Checkbox
-                              id="select-all"
-                              disabled={!currentList.length}
-                              onChange={e => onSelectAllCredentials(e.target.checked, currentList)}
-                            />
-                            {flexRender(header.column.columnDef.header, header.getContext())}
-                          </div>
-                        ) : (
-                          flexRender(header.column.columnDef.header, header.getContext())
-                        )}
-                      </th>
-                    ))}
+                    {headerGroup.headers.map(header =>
+                      header.isPlaceholder ? null : (
+                        <th id={header.id} key={header.id} className={css['table__item']}>
+                          {flexRender(header.column.columnDef.header, header.getContext())}
+                        </th>
+                      ),
+                    )}
                   </tr>
                 ))}
               </thead>
@@ -136,27 +122,11 @@ const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
                   {table.getRowModel().rows.map(row => {
                     return (
                       <tr key={row.id} className={css['row']}>
-                        {row.getVisibleCells().map(cell => {
-                          const item = cell.column.id === 'recipient_name' ? cell.row.original : null;
-                          return (
-                            <td className={css['col']} key={cell.id}>
-                              {cell.column.id === 'recipient_name' ? (
-                                <div className="flex justify-start items-center gap-3">
-                                  {item && (
-                                    <Checkbox
-                                      id={item.id}
-                                      checked={selectedCredentials.includes(item.id)}
-                                      onChange={() => onSelectCredential(item.id)}
-                                    />
-                                  )}
-                                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                                </div>
-                              ) : (
-                                flexRender(cell.column.columnDef.cell, cell.getContext())
-                              )}
-                            </td>
-                          );
-                        })}
+                        {row.getVisibleCells().map(cell => (
+                          <td className={css['col']} key={cell.id}>
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          </td>
+                        ))}
                       </tr>
                     );
                   })}
@@ -164,7 +134,7 @@ const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
               ) : (
                 <tbody>
                   <tr>
-                    <td colSpan={6}>
+                    <td colSpan={columns.length}>
                       <div className={css['table__empty']}>
                         {translate('credential-step2.empty-table-title')}
                         <span className={css['table__empty--lighter']}>

--- a/src/modules/Credential/containers/SchemaCredentialList/index.tsx
+++ b/src/modules/Credential/containers/SchemaCredentialList/index.tsx
@@ -17,8 +17,9 @@ import { SchemaCredentialListProps } from './index.types';
 
 const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
   selectedSchema,
-  selectedCredential,
+  selectedCredentials,
   onSelectCredential,
+  onSelectAllCredentials,
 }) => {
   const {
     data: { translate, currentList, page, totalPage, status, openModal },
@@ -30,7 +31,7 @@ const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
       onDeleteClick,
       onDeleteCredential,
     },
-  } = useSchemaCredentialList(selectedSchema.id, selectedCredential, onSelectCredential);
+  } = useSchemaCredentialList(selectedSchema.id, selectedCredentials, onSelectCredential);
 
   const columns = useMemo<ColumnDef<Credential>[]>(
     () => [
@@ -98,8 +99,8 @@ const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
           </Button>
           <Button
             variant="outlined"
-            color={!selectedCredential ? 'inherit' : 'primary'}
-            disabled={!selectedCredential || !currentList.length}
+            color={!selectedCredentials.length ? 'inherit' : 'primary'}
+            disabled={!selectedCredentials.length || !currentList.length}
             onClick={onDeleteClick}
           >
             {translate('credential-step2.delete-button')}
@@ -113,7 +114,18 @@ const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
                   <tr key={headerGroup.id}>
                     {headerGroup.headers.map(header => (
                       <th id={header.id} key={header.id} className={css['table__item']}>
-                        {flexRender(header.column.columnDef.header, header.getContext())}
+                        {header.id === 'recipient_name' ? (
+                          <div className="flex justify-start items-center gap-3 text-Gray-light-mode-600">
+                            <Checkbox
+                              id="select-all"
+                              disabled={!currentList.length}
+                              onChange={e => onSelectAllCredentials(e.target.checked, currentList)}
+                            />
+                            {flexRender(header.column.columnDef.header, header.getContext())}
+                          </div>
+                        ) : (
+                          flexRender(header.column.columnDef.header, header.getContext())
+                        )}
                       </th>
                     ))}
                   </tr>
@@ -133,7 +145,7 @@ const SchemaCredentialList: React.FC<SchemaCredentialListProps> = ({
                                   {item && (
                                     <Checkbox
                                       id={item.id}
-                                      checked={selectedCredential === item.id}
+                                      checked={selectedCredentials.includes(item.id)}
                                       onChange={() => onSelectCredential(item.id)}
                                     />
                                   )}

--- a/src/modules/Credential/containers/SchemaCredentialList/index.types.ts
+++ b/src/modules/Credential/containers/SchemaCredentialList/index.types.ts
@@ -1,8 +1,7 @@
-import { Credential, Schema } from 'src/core/adaptors';
+import { CredentialsRes, Schema } from 'src/core/adaptors';
 
 export interface SchemaCredentialListProps {
   selectedSchema: Schema;
-  selectedCredentials: string[];
-  onSelectCredential: (credentialId: string) => void;
-  onSelectAllCredentials: (checked: boolean, schemaCredentials: Credential[]) => void;
+  schemaCredentialList: CredentialsRes | null;
+  onUpdateSchemaCredentialList: (page: number) => void;
 }

--- a/src/modules/Credential/containers/SchemaCredentialList/index.types.ts
+++ b/src/modules/Credential/containers/SchemaCredentialList/index.types.ts
@@ -1,7 +1,8 @@
-import { Schema } from 'src/core/adaptors';
+import { Credential, Schema } from 'src/core/adaptors';
 
 export interface SchemaCredentialListProps {
   selectedSchema: Schema;
-  selectedCredential: string;
+  selectedCredentials: string[];
   onSelectCredential: (credentialId: string) => void;
+  onSelectAllCredentials: (checked: boolean, schemaCredentials: Credential[]) => void;
 }

--- a/src/modules/Credential/containers/SchemaCredentialList/useSchemaCredentialList.tsx
+++ b/src/modules/Credential/containers/SchemaCredentialList/useSchemaCredentialList.tsx
@@ -1,44 +1,31 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CredentialsRes, CredentialStatus, deleteCredentialsAdaptor, getCredentialsAdaptor } from 'src/core/adaptors';
-import { StatusProps } from 'src/modules/General/components/Status/index.types';
+import { CredentialsRes, deleteCredentialAdaptor } from 'src/core/adaptors';
 
 export const useSchemaCredentialList = (
-  selectedSchemaId: string,
-  selectedCredentials: string[],
-  onSelectCredential: (credentialId: string) => void,
+  schemaCredentialList: CredentialsRes | null,
+  onUpdateSchemaCredentialList: (page: number) => void,
 ) => {
   const { t: translate } = useTranslation();
-  const [currentSchemaCredentialList, setCurrentSchemaCredentialList] = useState<CredentialsRes>();
-  const currentList = currentSchemaCredentialList?.items || [];
+  const currentList = schemaCredentialList?.items || [];
   const [openModal, setOpenModal] = useState<{
     name: 'add' | 'delete' | '';
     open: boolean;
+    credentialId?: string;
   }>({
     name: '',
     open: false,
+    credentialId: '',
   });
   const [page, setPage] = useState(1);
-  const totalPage = Math.ceil((currentSchemaCredentialList?.total || 1) / (currentSchemaCredentialList?.limit || 10));
-  const status: Record<CredentialStatus, StatusProps> = {
-    ISSUED: { label: translate('credential-status.issued'), theme: 'warning' },
-    PENDING: { label: translate('credential-status.pending'), theme: 'warning' },
-    ACTIVE: { label: translate('credential-status.active'), theme: 'success' },
-    REVOKED: { label: translate('credential-status.revoked'), theme: 'error' },
-    CREATED: { label: translate('credential-status.created'), theme: 'warning' },
-  };
-
-  useEffect(() => {
-    onChangePage(page);
-  }, [selectedSchemaId]);
+  const totalPage = Math.ceil((schemaCredentialList?.total || 1) / (schemaCredentialList?.limit || 10));
 
   const onChangePage = async (newPage: number) => {
     setPage(newPage);
-    const { data } = await getCredentialsAdaptor(newPage, 10, { schema_id: selectedSchemaId });
-    data && setCurrentSchemaCredentialList(data);
+    onUpdateSchemaCredentialList(newPage);
   };
 
-  const handleCloseModal = () => setOpenModal({ name: '', open: false });
+  const handleCloseModal = () => setOpenModal({ name: '', open: false, credentialId: '' });
 
   const onAddCredentialRecipientClick = () => setOpenModal({ name: 'add', open: true });
 
@@ -47,21 +34,21 @@ export const useSchemaCredentialList = (
     handleCloseModal();
   };
 
-  const onDeleteClick = () => setOpenModal({ name: 'delete', open: true });
+  const onDeleteClick = (credentialId: string) => setOpenModal({ name: 'delete', open: true, credentialId });
 
   const onDeleteCredential = async () => {
-    if (selectedCredentials) {
-      const { error } = await deleteCredentialsAdaptor(selectedCredentials);
+    const selectedCredential = openModal?.credentialId || '';
+    if (selectedCredential) {
+      const { error } = await deleteCredentialAdaptor(selectedCredential);
       if (error) return;
-      const filteredList = currentList.filter(list => !selectedCredentials.includes(list.id));
+      const filteredList = currentList.filter(list => list.id !== selectedCredential);
       onChangePage(filteredList.length === 0 && page > 1 ? page - 1 : page);
-      onSelectCredential('');
       handleCloseModal();
     }
   };
 
   return {
-    data: { translate, currentList, page, totalPage, status, openModal },
+    data: { translate, currentList, page, totalPage, openModal },
     operations: {
       onChangePage,
       onAddCredentialRecipientClick,

--- a/src/modules/Credential/containers/SchemaCredentialList/useSchemaCredentialList.tsx
+++ b/src/modules/Credential/containers/SchemaCredentialList/useSchemaCredentialList.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CredentialsRes, CredentialStatus, deleteCredentialAdaptor, getCredentialsAdaptor } from 'src/core/adaptors';
+import { CredentialsRes, CredentialStatus, deleteCredentialsAdaptor, getCredentialsAdaptor } from 'src/core/adaptors';
 import { StatusProps } from 'src/modules/General/components/Status/index.types';
 
 export const useSchemaCredentialList = (
   selectedSchemaId: string,
-  selectedCredential: string,
+  selectedCredentials: string[],
   onSelectCredential: (credentialId: string) => void,
 ) => {
   const { t: translate } = useTranslation();
@@ -50,10 +50,10 @@ export const useSchemaCredentialList = (
   const onDeleteClick = () => setOpenModal({ name: 'delete', open: true });
 
   const onDeleteCredential = async () => {
-    if (selectedCredential) {
-      const { error } = await deleteCredentialAdaptor(selectedCredential);
+    if (selectedCredentials) {
+      const { error } = await deleteCredentialsAdaptor(selectedCredentials);
       if (error) return;
-      const filteredList = currentList.filter(list => list.id !== selectedCredential);
+      const filteredList = currentList.filter(list => !selectedCredentials.includes(list.id));
       onChangePage(filteredList.length === 0 && page > 1 ? page - 1 : page);
       onSelectCredential('');
       handleCloseModal();

--- a/src/modules/General/components/Input/index.module.scss
+++ b/src/modules/General/components/Input/index.module.scss
@@ -67,6 +67,7 @@
         width: 100%;
         height: 100% !important;
         overflow-y: auto !important;
+        overflow-wrap: break-word;
 
         &::placeholder {
             color: $color-grey-500;

--- a/src/pages/credentials/create/index.module.scss
+++ b/src/pages/credentials/create/index.module.scss
@@ -11,9 +11,7 @@
     }
 
     .pagination {
-        //FIXME: for now because there is two steps
-        // width: calc(100% / 3);
-        width: calc(100% / 2);
+        width: calc(100% / 3);
 
         @media (max-width: $md) {
             width: 100%;

--- a/src/pages/credentials/create/index.tsx
+++ b/src/pages/credentials/create/index.tsx
@@ -1,4 +1,5 @@
 import { Divider } from '@mui/material';
+import PreviewCredential from 'src/modules/Credential/containers/PreviewCredential';
 import SchemaCredentialList from 'src/modules/Credential/containers/SchemaCredentialList';
 import SelectSchema from 'src/modules/Credential/containers/SelectSchema';
 import Button from 'src/modules/General/components/Button';
@@ -18,17 +19,18 @@ export const Create = () => {
       schemaRadioItems,
       selectedSchema,
       selectedSchemaDetail,
-      selectedCredentials,
+      schemaCredentialList,
       disabledButton,
       formRef,
+      schemaCredentialDetail,
     },
     operations: {
       onCancelCreate,
       handleContinue,
       onChangePage,
       setSelectedSchema,
-      onSelectCredential,
-      onSelectAllCredentials,
+      onUpdateSchemaCredentialList,
+      onSendCredential,
     },
   } = useCreate();
 
@@ -43,20 +45,25 @@ export const Create = () => {
     1: selectedSchemaDetail && (
       <SchemaCredentialList
         selectedSchema={selectedSchemaDetail}
-        selectedCredentials={selectedCredentials}
-        onSelectCredential={onSelectCredential}
-        onSelectAllCredentials={onSelectAllCredentials}
+        schemaCredentialList={schemaCredentialList}
+        onUpdateSchemaCredentialList={onUpdateSchemaCredentialList}
       />
     ),
-    2: <p>Not developed yet</p>,
+    2: (
+      <PreviewCredential ref={formRef} credentialDetail={schemaCredentialDetail} onSendCredential={onSendCredential} />
+    ),
   };
 
   return (
     <div className={css['container']}>
       <PaginationDotGroup
         shape="oval"
-        titles={[translate('credential-step1-title'), translate('credential-step2-title')]}
-        count={2}
+        titles={[
+          translate('credential-step1-title'),
+          translate('credential-step2-title'),
+          translate('credential-step3-title'),
+        ]}
+        count={3}
         active={step}
         size="xs"
         transparent

--- a/src/pages/credentials/create/index.tsx
+++ b/src/pages/credentials/create/index.tsx
@@ -18,11 +18,18 @@ export const Create = () => {
       schemaRadioItems,
       selectedSchema,
       selectedSchemaDetail,
-      selectedCredential,
+      selectedCredentials,
       disabledButton,
       formRef,
     },
-    operations: { onCancelCreate, handleContinue, onChangePage, setSelectedSchema, onSelectCredential },
+    operations: {
+      onCancelCreate,
+      handleContinue,
+      onChangePage,
+      setSelectedSchema,
+      onSelectCredential,
+      onSelectAllCredentials,
+    },
   } = useCreate();
 
   const content = {
@@ -36,8 +43,9 @@ export const Create = () => {
     1: selectedSchemaDetail && (
       <SchemaCredentialList
         selectedSchema={selectedSchemaDetail}
-        selectedCredential={selectedCredential}
+        selectedCredentials={selectedCredentials}
         onSelectCredential={onSelectCredential}
+        onSelectAllCredentials={onSelectAllCredentials}
       />
     ),
     2: <p>Not developed yet</p>,

--- a/src/pages/credentials/create/useCreate.tsx
+++ b/src/pages/credentials/create/useCreate.tsx
@@ -15,10 +15,10 @@ export const useCreate = () => {
   const [selectedSchema, setSelectedSchema] = useState(
     (currentList[0]?.disabled ? currentList[1]?.id : currentList[0]?.id) || '',
   );
-  const [selectedCredential, setSelectedCredential] = useState('');
+  const [selectedCredentials, setSelectedCredentials] = useState<string[]>([]);
   const selectedSchemaDetail = currentList.find(schema => schema.id === selectedSchema);
   const formRef = useRef<{ submitForm: () => void }>(null);
-  const disabledButton = step === 1 && !selectedCredential;
+  const disabledButton = step === 1 && !selectedCredentials.length;
 
   const schemaRadioItems = currentList.map(schema => ({
     id: schema.id,
@@ -42,12 +42,17 @@ export const useCreate = () => {
   };
 
   const onSelectCredential = (id: string) => {
-    //FIXME: for now because bulk action is out of scope of this PR
-    if (selectedCredential === id) {
-      setSelectedCredential('');
-    } else {
-      setSelectedCredential(id);
-    }
+    setSelectedCredentials(selected =>
+      selected.includes(id) ? selected.filter(credential => credential !== id) : [...selected, id],
+    );
+  };
+
+  const onSelectAllCredentials = (checked: boolean, schemaCredentials: Credential[]) => {
+    if (checked) {
+      const ids = schemaCredentials.map(list => list.id);
+      const allSelected = [...new Set([...selectedCredentials, ...ids])];
+      setSelectedCredentials(allSelected);
+    } else setSelectedCredentials([]);
   };
 
   const onSendCredential = async () => {
@@ -70,10 +75,17 @@ export const useCreate = () => {
       schemaRadioItems,
       selectedSchema,
       selectedSchemaDetail,
-      selectedCredential,
+      selectedCredentials,
       disabledButton,
       formRef,
     },
-    operations: { onCancelCreate, handleContinue, onChangePage, setSelectedSchema, onSelectCredential },
+    operations: {
+      onCancelCreate,
+      handleContinue,
+      onChangePage,
+      setSelectedSchema,
+      onSelectCredential,
+      onSelectAllCredentials,
+    },
   };
 };


### PR DESCRIPTION
**This branch is related to step 3 `send credential` for showing credentials and sending them to recipients**

**Also,** includes:
- [x] fixed and added `word-break` style for multi-line input
- [x] handled bulk `delete/revoke` on the credentials list (`/credentials` page) 
- [x] refactored and removed bulk `delete` for the credentials list on `step-2` and added a `trash` icon for each credential to remove
- [x] brought the logic for fetching/updating the `schema credentials` list outside of the step-2 component (`SchemaCredentialList`) and moved to the page ('/credentials/create`)

TODO:
- [x] changing steps logic according to new changes in design
- [x] showing `message` and  a preview of the email to users - FE
- [x] enable bulk check box on credentials list - FE
- [x] ~~button link on the preview of email - FE~~
- [x] check the API calls for sending bulk and deleting and revoking bulk - BE 
- [x] needs to be merged https://github.com/socious-io/shin-webapp/pull/86 first
- [x] final check